### PR TITLE
Fix OAuth callback server race condition

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -31,6 +31,17 @@ export async function addAccount(): Promise<string> {
           const url = new URL(req.url ?? '', redirectUri);
           const code = url.searchParams.get('code');
           const err = url.searchParams.get('error');
+
+          // Ignore stray requests (e.g. the browser fetching /favicon.ico) that
+          // aren't the actual OAuth redirect — only the real callback carries a
+          // `code` or `error` param. Closing the server on the first request
+          // regardless of that lost the race against the real redirect.
+          if (!err && !code) {
+            res.writeHead(404);
+            res.end();
+            return;
+          }
+
           res.writeHead(200, { 'Content-Type': 'text/plain' });
           res.end(err ? `Auth error: ${err}` : 'Authorized. You can close this tab.');
           httpServer.close();


### PR DESCRIPTION
## Summary
- The loopback OAuth callback server closed itself on the very first HTTP request it received, regardless of whether that request actually carried the OAuth `code`. A stray request (e.g. the browser fetching `/favicon.ico`) arriving before the real redirect would win the race, get shown the "Authorized" message, and cause the real callback to be missed — surfacing as `Error: no code` even though the browser showed success.
- Now the server only treats a request as the callback if it carries a `code` or `error` param; anything else gets a 404 and the server keeps waiting for the real one.

Found this while authorizing a second Google account with `add-account` — first account worked (real redirect won the race), second one consistently hit the race and failed.

## Test plan
- [ ] Ran `add-account` repeatedly against a fresh account and confirmed it now succeeds consistently instead of intermittently failing with "no code"