### PR TITLE
Surface document title and suggestion preview in apply_suggestion

### DIFF
--- a/src/docs/suggestions.ts
+++ b/src/docs/suggestions.ts
@@ -91,14 +91,28 @@ function isContiguous(spans: Span[]): boolean {
   return true;
 }
 
+// Short human-readable summary of a suggestion, independent of accept/reject.
+// Callers echo this back into apply_suggestion (as `expectedChange`) so the
+// permission prompt shows what's actually being resolved instead of a bare id,
+// and so a stale/wrong id gets caught before anything is applied.
+export function formatSuggestionPreview(s: Pick<Suggestion, 'type' | 'before' | 'after'>): string {
+  const before = s.before.trim();
+  const after = s.after.trim();
+  if (s.type === 'insertion') return `insert: "${after}"`;
+  if (s.type === 'deletion') return `delete: "${before}"`;
+  if (s.type === 'replacement') return `"${before}" → "${after}"`;
+  return '(style change)';
+}
+
 export async function listSuggestions(
   clients: GoogleClients,
   documentId: string,
   tab?: string,
-): Promise<{ revisionId: string; suggestions: Suggestion[] }> {
+): Promise<{ revisionId: string; title: string; suggestions: (Suggestion & { preview: string })[] }> {
   const doc = await getDocInline(clients, documentId);
   const tabId = resolveTabId(doc, tab);
-  return { revisionId: doc.revisionId ?? '', suggestions: parseSuggestions(doc, tabId) };
+  const suggestions = parseSuggestions(doc, tabId).map((s) => ({ ...s, preview: formatSuggestionPreview(s) }));
+  return { revisionId: doc.revisionId ?? '', title: doc.title ?? '', suggestions };
 }
 
 // Resolve a suggestion by reconstructing its tagged span (spike-validated):
@@ -122,14 +136,23 @@ export async function applySuggestion(
   documentId: string,
   suggestionId: string,
   decision: 'accept' | 'reject',
+  expectedChange: string,
   tab?: string,
-): Promise<{ status: 'ok' | 'not_found' | 'unsupported'; message?: string }> {
+): Promise<{ status: 'ok' | 'not_found' | 'unsupported' | 'stale'; message?: string }> {
   const doc = await getDocInline(clients, documentId);
   const tabId = resolveTabId(doc, tab);
   const s = parseSuggestions(doc, tabId).find((x) => x.id === suggestionId);
   if (!s) return { status: 'not_found', message: `suggestion ${suggestionId} not found (may be already resolved)` };
   if (s.type === 'style') return { status: 'unsupported', message: 'style-only suggestions are not yet resolvable' };
   if (!s.contiguous) return { status: 'unsupported', message: 'non-contiguous suggestion span' };
+
+  const actual = formatSuggestionPreview(s);
+  if (actual !== expectedChange) {
+    return {
+      status: 'stale',
+      message: `expectedChange did not match the live suggestion (expected "${expectedChange}", found "${actual}"). The doc may have changed since list_suggestions, or this id belongs to a different suggestion. Re-run list_suggestions and retry with the current preview.`,
+    };
+  }
 
   await clients.docs.documents.batchUpdate({
     documentId,

--- a/src/server.ts
+++ b/src/server.ts
@@ -214,18 +214,25 @@ export function createServer(): McpServer {
     {
       title: 'Accept or reject a suggestion',
       description:
-        'Resolve a pending suggestion by id (from list_suggestions): accept keeps the proposed text, reject keeps the original. Cleanly removes the suggestion.',
+        'Resolve a pending suggestion by id (from list_suggestions): accept keeps the proposed text, reject keeps the original. Cleanly removes the suggestion. ' +
+        'Always call list_suggestions first and copy its `title` and the suggestion\'s `preview` verbatim into documentTitle/expectedChange — this is what a human reviewing the tool call sees, and it is also checked against the live suggestion before applying, so a stale or wrong id is rejected instead of silently resolved.',
       inputSchema: {
         documentId: z.string().describe('Google Doc id'),
+        documentTitle: z.string().describe("The document's title, from list_suggestions' `title` field. Shown for confirmation only."),
         suggestionId: z.string().describe('suggestion id from list_suggestions'),
+        expectedChange: z
+          .string()
+          .describe(
+            "The suggestion's `preview` string, copied exactly from list_suggestions. Shown for confirmation, and must match the live suggestion or the call is rejected.",
+          ),
         decision: z.enum(['accept', 'reject']),
         ...tabArg,
         ...accountArg,
       },
     },
-    async ({ documentId, suggestionId, decision, tab, account }) => {
+    async ({ documentId, documentTitle: _documentTitle, suggestionId, expectedChange, decision, tab, account }) => {
       const clients = await clientsForAccount(account);
-      return json(await applySuggestion(clients, documentId, suggestionId, decision, tab));
+      return json(await applySuggestion(clients, documentId, suggestionId, decision, expectedChange, tab));
     },
   );
 

--- a/test/suggestions.test.ts
+++ b/test/suggestions.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import type { docs_v1 } from 'googleapis';
-import { parseSuggestions } from '../src/docs/suggestions.js';
+import type { GoogleClients } from '../src/google/clients.js';
+import { parseSuggestions, formatSuggestionPreview, applySuggestion } from '../src/docs/suggestions.js';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
@@ -42,5 +43,68 @@ describe('parseSuggestions', () => {
     const suggestions = parseSuggestions(doc, doc.tabs?.[0]?.tabProperties?.tabId);
     expect(suggestions).toHaveLength(1);
     expect(suggestions[0]).toMatchObject({ type: 'replacement', before: '3 weeks', after: '2 weeks', contiguous: true });
+  });
+});
+
+describe('formatSuggestionPreview', () => {
+  it('formats an insertion', () => {
+    expect(formatSuggestionPreview({ type: 'insertion', before: '', after: 'add' })).toBe('insert: "add"');
+  });
+
+  it('formats a deletion', () => {
+    expect(formatSuggestionPreview({ type: 'deletion', before: 'old', after: '' })).toBe('delete: "old"');
+  });
+
+  it('formats a replacement', () => {
+    expect(formatSuggestionPreview({ type: 'replacement', before: '3 weeks', after: '2 weeks' })).toBe('"3 weeks" → "2 weeks"');
+  });
+
+  it('formats a style-only change', () => {
+    expect(formatSuggestionPreview({ type: 'style', before: '', after: '' })).toBe('(style change)');
+  });
+
+  it('trims whitespace so previews match regardless of trailing spaces in the doc', () => {
+    expect(formatSuggestionPreview({ type: 'insertion', before: '', after: 'add ' })).toBe('insert: "add"');
+  });
+});
+
+describe('applySuggestion staleness check', () => {
+  const doc: docs_v1.Schema$Document = {
+    revisionId: 'rev1',
+    body: {
+      content: [
+        { paragraph: { elements: [{ startIndex: 1, endIndex: 4, textRun: { content: 'add', suggestedInsertionIds: ['s1'] } }] } },
+      ],
+    },
+  };
+
+  function fakeClients(batchUpdate = vi.fn().mockResolvedValue({})): GoogleClients {
+    return {
+      account: 'test@example.com',
+      auth: {} as GoogleClients['auth'],
+      docs: {
+        documents: {
+          get: vi.fn().mockResolvedValue({ data: doc }),
+          batchUpdate,
+        },
+      } as unknown as GoogleClients['docs'],
+      drive: {} as GoogleClients['drive'],
+    };
+  }
+
+  it('refuses to apply when expectedChange does not match the live suggestion', async () => {
+    const batchUpdate = vi.fn().mockResolvedValue({});
+    const clients = fakeClients(batchUpdate);
+    const result = await applySuggestion(clients, 'doc1', 's1', 'reject', 'insert: "something else"');
+    expect(result.status).toBe('stale');
+    expect(batchUpdate).not.toHaveBeenCalled();
+  });
+
+  it('applies when expectedChange matches the live suggestion', async () => {
+    const batchUpdate = vi.fn().mockResolvedValue({});
+    const clients = fakeClients(batchUpdate);
+    const result = await applySuggestion(clients, 'doc1', 's1', 'reject', 'insert: "add"');
+    expect(result.status).toBe('ok');
+    expect(batchUpdate).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- `apply_suggestion` only took opaque `documentId`/`suggestionId`, so the permission prompt shown before the call had nothing human-readable to check — a real problem reviewing suggestions across near-identical documents (e.g. two client entities' near-identical agreements).
- `list_suggestions` now also returns the doc's `title` and a `preview` string per suggestion (`"3 weeks" → "2 weeks"`, `insert: "..."`, `delete: "..."`).
- `apply_suggestion` gains `documentTitle`/`expectedChange` params, copied verbatim from the prior `list_suggestions` call — these show up in the permission prompt in place of bare ids.
- Bonus: the server re-verifies `expectedChange` against the live suggestion before applying, and refuses (`status: stale`) if it doesn't match, catching a stale id or a doc that changed since `list_suggestions` was called.

Fixes #4

## Test plan
- [x] Unit tests: `formatSuggestionPreview` (insertion/deletion/replacement/style/whitespace-trim) and `applySuggestion` staleness check (rejects on mismatch, applies on match) — `test/suggestions.test.ts`, all passing
- [x] Typecheck clean
- [x] Live-tested against a real doc (Colorado Pinball bookkeeping agreement, 9 pending DBA-wording suggestions) — permission prompt showed the real doc title and accurate before→after previews instead of opaque ids