### PR TITLE
Verify documentTitle against the live doc in apply_suggestion(s)

### DIFF
--- a/src/docs/suggestions.ts
+++ b/src/docs/suggestions.ts
@@ -261,20 +261,33 @@ function regionRequests(
 }
 
 export interface ApplyResult {
-  status: 'ok' | 'not_found' | 'unsupported' | 'stale' | 'cluster';
+  status: 'ok' | 'not_found' | 'unsupported' | 'stale' | 'cluster' | 'wrong_doc';
   message?: string;
   cluster?: { suggestionId: string; preview: string }[];
+}
+
+// Anchors a call to the document, not just the change (#9): a same-worded
+// suggestion can exist in two near-identical documents, and expectedChange
+// alone wouldn't catch approving it on the wrong one.
+function checkDocumentTitle(doc: docs_v1.Schema$Document, documentTitle: string): string | undefined {
+  const actual = doc.title ?? '';
+  if (actual === documentTitle) return undefined;
+  return `documentTitle did not match the live document (expected "${documentTitle}", found "${actual}"). This id may belong to a different, similarly-titled document — re-run list_suggestions on the intended document and retry.`;
 }
 
 export async function applySuggestion(
   clients: GoogleClients,
   documentId: string,
+  documentTitle: string,
   suggestionId: string,
   decision: 'accept' | 'reject',
   expectedChange: string,
   tab?: string,
 ): Promise<ApplyResult> {
   const doc = await getDocInline(clients, documentId);
+  const wrongDoc = checkDocumentTitle(doc, documentTitle);
+  if (wrongDoc) return { status: 'wrong_doc', message: wrongDoc };
+
   const tabId = resolveTabId(doc, tab);
   const suggestions = parseSuggestions(doc, tabId);
   const s = suggestions.find((x) => x.id === suggestionId);
@@ -324,7 +337,7 @@ export interface Resolution {
 }
 
 export interface ApplyManyResult {
-  status: 'ok' | 'error' | 'incomplete';
+  status: 'ok' | 'error' | 'incomplete' | 'wrong_doc';
   resolved?: number;
   errors?: string[];
   /** Overlapping insert-inside-delete conflicts that were auto-resolved (insertion kept). */
@@ -337,10 +350,14 @@ export interface ApplyManyResult {
 export async function applySuggestions(
   clients: GoogleClients,
   documentId: string,
+  documentTitle: string,
   resolutions: Resolution[],
   tab?: string,
 ): Promise<ApplyManyResult> {
   const doc = await getDocInline(clients, documentId);
+  const wrongDoc = checkDocumentTitle(doc, documentTitle);
+  if (wrongDoc) return { status: 'wrong_doc', errors: [wrongDoc] };
+
   const tabId = resolveTabId(doc, tab);
   const suggestions = parseSuggestions(doc, tabId);
   const byId = new Map(suggestions.map((s) => [s.id, s]));

--- a/src/server.ts
+++ b/src/server.ts
@@ -264,7 +264,7 @@ export function createServer(): McpServer {
       title: 'Accept or reject a suggestion',
       description:
         'Resolve a pending suggestion by id (from list_suggestions): accept keeps the proposed text, reject keeps the original. Cleanly removes the suggestion. ' +
-        'Always call list_suggestions first and copy its `title` and the suggestion\'s `preview` verbatim into documentTitle/expectedChange — this is what a human reviewing the tool call sees, and it is also checked against the live suggestion before applying, so a stale or wrong id is rejected instead of silently resolved. ' +
+        'Always call list_suggestions first and copy its `title` and the suggestion\'s `preview` verbatim into documentTitle/expectedChange — this is what a human reviewing the tool call sees, and both are checked against the live document/suggestion before applying (status "wrong_doc" or "stale" on mismatch), so a stale id or an id from a different, similarly-titled document is rejected instead of silently resolved. ' +
         'If the suggestion overlaps or adjoins others (a cluster), this returns status "cluster" with the members — resolve them together via apply_suggestions instead (resolving a cluster one-at-a-time corrupts neighbours).',
       inputSchema: {
         documentId: z.string().describe('Google Doc id'),
@@ -280,9 +280,9 @@ export function createServer(): McpServer {
         ...accountArg,
       },
     },
-    async ({ documentId, documentTitle: _documentTitle, suggestionId, expectedChange, decision, tab, account }) => {
+    async ({ documentId, documentTitle, suggestionId, expectedChange, decision, tab, account }) => {
       const clients = await clientsForAccount(account);
-      return json(await applySuggestion(clients, documentId, suggestionId, decision, expectedChange, tab));
+      return json(await applySuggestion(clients, documentId, documentTitle, suggestionId, decision, expectedChange, tab));
     },
   );
 
@@ -291,7 +291,7 @@ export function createServer(): McpServer {
     {
       title: 'Accept/reject multiple suggestions atomically',
       description:
-        'Resolve several suggestions in ONE atomic update — required for suggestions that overlap or adjoin each other (a "cluster"), which cannot be resolved one at a time without corrupting neighbours. You MUST include every suggestion in any cluster you touch; a partially-resolved cluster is refused (status "incomplete"). Copy each suggestion\'s `preview` from list_suggestions into its `expectedChange` (verified before applying). If the result includes a `conflicts` array, two suggestions genuinely conflicted (one inserts text inside another\'s deletion, both accepted) — it was auto-resolved by keeping the insertion; surface this to the user as NOT a clean merge.',
+        'Resolve several suggestions in ONE atomic update — required for suggestions that overlap or adjoin each other (a "cluster"), which cannot be resolved one at a time without corrupting neighbours. You MUST include every suggestion in any cluster you touch; a partially-resolved cluster is refused (status "incomplete"). documentTitle is checked against the live document first (status "wrong_doc" on mismatch, e.g. an id from a different, similarly-titled document). Copy each suggestion\'s `preview` from list_suggestions into its `expectedChange` (verified before applying). If the result includes a `conflicts` array, two suggestions genuinely conflicted (one inserts text inside another\'s deletion, both accepted) — it was auto-resolved by keeping the insertion; surface this to the user as NOT a clean merge.',
       inputSchema: {
         documentId: z.string().describe('Google Doc id'),
         documentTitle: z.string().describe("The document's title, from list_suggestions. Shown for confirmation only."),
@@ -308,9 +308,9 @@ export function createServer(): McpServer {
         ...accountArg,
       },
     },
-    async ({ documentId, documentTitle: _documentTitle, resolutions, tab, account }) => {
+    async ({ documentId, documentTitle, resolutions, tab, account }) => {
       const clients = await clientsForAccount(account);
-      return json(await applySuggestions(clients, documentId, resolutions, tab));
+      return json(await applySuggestions(clients, documentId, documentTitle, resolutions, tab));
     },
   );
 

--- a/test/suggestions.test.ts
+++ b/test/suggestions.test.ts
@@ -81,6 +81,7 @@ describe('formatSuggestionPreview', () => {
 describe('applySuggestion staleness check', () => {
   const doc: docs_v1.Schema$Document = {
     revisionId: 'rev1',
+    title: 'Test Doc',
     body: {
       content: [
         { paragraph: { elements: [{ startIndex: 1, endIndex: 4, textRun: { content: 'add', suggestedInsertionIds: ['s1'] } }] } },
@@ -105,7 +106,7 @@ describe('applySuggestion staleness check', () => {
   it('refuses to apply when expectedChange does not match the live suggestion', async () => {
     const batchUpdate = vi.fn().mockResolvedValue({});
     const clients = fakeClients(batchUpdate);
-    const result = await applySuggestion(clients, 'doc1', 's1', 'reject', 'insert: "something else"');
+    const result = await applySuggestion(clients, 'doc1', 'Test Doc', 's1', 'reject', 'insert: "something else"');
     expect(result.status).toBe('stale');
     expect(batchUpdate).not.toHaveBeenCalled();
   });
@@ -113,9 +114,51 @@ describe('applySuggestion staleness check', () => {
   it('applies when expectedChange matches the live suggestion', async () => {
     const batchUpdate = vi.fn().mockResolvedValue({});
     const clients = fakeClients(batchUpdate);
-    const result = await applySuggestion(clients, 'doc1', 's1', 'reject', 'insert: "add"');
+    const result = await applySuggestion(clients, 'doc1', 'Test Doc', 's1', 'reject', 'insert: "add"');
     expect(result.status).toBe('ok');
     expect(batchUpdate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('applySuggestion / applySuggestions — documentTitle check (#9)', () => {
+  const doc: docs_v1.Schema$Document = {
+    revisionId: 'rev1',
+    title: 'Test Doc',
+    body: {
+      content: [
+        { paragraph: { elements: [{ startIndex: 1, endIndex: 4, textRun: { content: 'add', suggestedInsertionIds: ['s1'] } }] } },
+      ],
+    },
+  };
+
+  function fakeClients(batchUpdate = vi.fn().mockResolvedValue({})): GoogleClients {
+    return {
+      account: 'test@example.com',
+      auth: {} as GoogleClients['auth'],
+      docs: {
+        documents: {
+          get: vi.fn().mockResolvedValue({ data: doc }),
+          batchUpdate,
+        },
+      } as unknown as GoogleClients['docs'],
+      drive: {} as GoogleClients['drive'],
+    };
+  }
+
+  it('applySuggestion refuses when documentTitle does not match the live document', async () => {
+    const batchUpdate = vi.fn().mockResolvedValue({});
+    const result = await applySuggestion(fakeClients(batchUpdate), 'doc1', 'Wrong Doc', 's1', 'reject', 'insert: "add"');
+    expect(result.status).toBe('wrong_doc');
+    expect(batchUpdate).not.toHaveBeenCalled();
+  });
+
+  it('applySuggestions refuses when documentTitle does not match the live document', async () => {
+    const batchUpdate = vi.fn().mockResolvedValue({});
+    const result = await applySuggestions(fakeClients(batchUpdate), 'doc1', 'Wrong Doc', [
+      { suggestionId: 's1', decision: 'reject', expectedChange: 'insert: "add"' },
+    ]);
+    expect(result.status).toBe('wrong_doc');
+    expect(batchUpdate).not.toHaveBeenCalled();
   });
 });
 
@@ -185,6 +228,7 @@ describe('resolveRegionText', () => {
 function docFromRuns(runs: { content: string; start: number; ins?: string; del?: string }[]): docs_v1.Schema$Document {
   return {
     revisionId: 'rev1',
+    title: 'Test Doc',
     body: {
       content: [
         {
@@ -226,7 +270,7 @@ const clusterDoc = () =>
 describe('applySuggestion — cluster safety (#7)', () => {
   it('refuses to resolve a clustered suggestion and does NOT mutate', async () => {
     const batchUpdate = vi.fn().mockResolvedValue({});
-    const res = await applySuggestion(clientsFor(clusterDoc(), batchUpdate), 'd', 's1', 'accept', 'insert: "new"');
+    const res = await applySuggestion(clientsFor(clusterDoc(), batchUpdate), 'd', 'Test Doc', 's1', 'accept', 'insert: "new"');
     expect(res.status).toBe('cluster');
     expect(res.cluster?.map((c) => c.suggestionId).sort()).toEqual(['s1', 's2']);
     expect(batchUpdate).not.toHaveBeenCalled();
@@ -238,7 +282,7 @@ describe('applySuggestion — cluster safety (#7)', () => {
       { content: '3 weeks', start: 8, del: 's1' },
     ]);
     const batchUpdate = vi.fn().mockResolvedValue({});
-    const res = await applySuggestion(clientsFor(doc, batchUpdate), 'd', 's1', 'accept', '"3 weeks" → "2 weeks"');
+    const res = await applySuggestion(clientsFor(doc, batchUpdate), 'd', 'Test Doc', 's1', 'accept', '"3 weeks" → "2 weeks"');
     expect(res.status).toBe('ok');
     expect(batchUpdate).toHaveBeenCalledTimes(1);
     const reqs = batchUpdate.mock.calls[0][0].requestBody.requests;
@@ -250,7 +294,7 @@ describe('applySuggestion — cluster safety (#7)', () => {
 describe('applySuggestions — atomic cluster resolution (#7)', () => {
   it('resolves a full cluster in one batchUpdate with correct merged text', async () => {
     const batchUpdate = vi.fn().mockResolvedValue({});
-    const res = await applySuggestions(clientsFor(clusterDoc(), batchUpdate), 'd', [
+    const res = await applySuggestions(clientsFor(clusterDoc(), batchUpdate), 'd', 'Test Doc', [
       { suggestionId: 's1', decision: 'accept', expectedChange: 'insert: "new"' },
       { suggestionId: 's2', decision: 'accept', expectedChange: 'delete: "old"' },
     ]);
@@ -264,7 +308,7 @@ describe('applySuggestions — atomic cluster resolution (#7)', () => {
 
   it('refuses a partially-resolved cluster (incomplete) and does NOT mutate', async () => {
     const batchUpdate = vi.fn().mockResolvedValue({});
-    const res = await applySuggestions(clientsFor(clusterDoc(), batchUpdate), 'd', [
+    const res = await applySuggestions(clientsFor(clusterDoc(), batchUpdate), 'd', 'Test Doc', [
       { suggestionId: 's1', decision: 'accept', expectedChange: 'insert: "new"' },
     ]);
     expect(res.status).toBe('incomplete');
@@ -274,7 +318,7 @@ describe('applySuggestions — atomic cluster resolution (#7)', () => {
 
   it('refuses on any expectedChange mismatch and does NOT mutate', async () => {
     const batchUpdate = vi.fn().mockResolvedValue({});
-    const res = await applySuggestions(clientsFor(clusterDoc(), batchUpdate), 'd', [
+    const res = await applySuggestions(clientsFor(clusterDoc(), batchUpdate), 'd', 'Test Doc', [
       { suggestionId: 's1', decision: 'accept', expectedChange: 'insert: "WRONG"' },
       { suggestionId: 's2', decision: 'accept', expectedChange: 'delete: "old"' },
     ]);
@@ -287,6 +331,7 @@ describe('applySuggestion — style metadata on edit runs (#7 regression)', () =
   it('resolves an insertion run that also carries suggestedTextStyleChanges (not treated as style-only)', async () => {
     const doc = {
       revisionId: 'r',
+      title: 'Test Doc',
       body: {
         content: [
           {
@@ -300,7 +345,7 @@ describe('applySuggestion — style metadata on edit runs (#7 regression)', () =
       },
     } as unknown as docs_v1.Schema$Document;
     const batchUpdate = vi.fn().mockResolvedValue({});
-    const res = await applySuggestion(clientsFor(doc, batchUpdate), 'd', 's1', 'accept', 'insert: "new"');
+    const res = await applySuggestion(clientsFor(doc, batchUpdate), 'd', 'Test Doc', 's1', 'accept', 'insert: "new"');
     expect(res.status).toBe('ok');
     expect(batchUpdate).toHaveBeenCalledTimes(1);
   });
@@ -336,7 +381,7 @@ describe('detectConflicts (#11)', () => {
 describe('applySuggestions — surfaces conflicts (#11)', () => {
   it('resolves atomically but reports the auto-resolved conflict', async () => {
     const batchUpdate = vi.fn().mockResolvedValue({});
-    const res = await applySuggestions(clientsFor(conflictDoc(), batchUpdate), 'd', [
+    const res = await applySuggestions(clientsFor(conflictDoc(), batchUpdate), 'd', 'Test Doc', [
       { suggestionId: 's1', decision: 'accept' },
       { suggestionId: 's2', decision: 'accept' },
     ]);
@@ -348,7 +393,7 @@ describe('applySuggestions — surfaces conflicts (#11)', () => {
   });
 
   it('reports no conflicts for a clean (non-overlapping) cluster', async () => {
-    const res = await applySuggestions(clientsFor(clusterDoc()), 'd', [
+    const res = await applySuggestions(clientsFor(clusterDoc()), 'd', 'Test Doc', [
       { suggestionId: 's1', decision: 'accept' },
       { suggestionId: 's2', decision: 'accept' },
     ]);


### PR DESCRIPTION
## Summary
- `documentTitle` was already a required schema param on both `apply_suggestion` and `apply_suggestions` (shown in the permission prompt for confirmation), but was discarded (`documentTitle: _documentTitle`) rather than checked — only `expectedChange` was verified.
- Both functions now compare the passed `documentTitle` against the live `doc.title` (from the same `documents.get` call already made for the existing checks) before doing anything else, returning `status: "wrong_doc"` on mismatch — same shape as the existing `"stale"` status, just anchored to the *document* instead of the suggestion's content.
- This directly protects the scenario that motivated #6: two near-identical documents (e.g. two client entities) can have suggestions with the same wording, so `expectedChange` alone wouldn't catch approving a same-worded change on the wrong document.

Fixes #9

## Test plan
- [x] New unit tests: `applySuggestion` and `applySuggestions` both refuse with `wrong_doc` on a documentTitle mismatch, and don't call `batchUpdate` — mirrors the existing staleness tests
- [x] All existing tests updated to pass a matching `documentTitle` (fixture docs now carry an explicit `title`) — confirms the new check doesn't false-positive on the existing suite
- [x] Typecheck clean, 114/114 tests passing, build succeeds